### PR TITLE
Add perl implementation of JSON Test services

### DIFF
--- a/perl/JsonTests.pl
+++ b/perl/JsonTests.pl
@@ -107,3 +107,10 @@ To learn more, you can browse through the documentation
   <head><title><%= title %></title></head>
   <body><%= content %></body>
 </html>
+
+@@ not_found.html.ep
+<!DOCTYPE html>
+<html>
+  <head><title>Page not found</title></head>
+  <body>Page not found <%= $status %></body>
+</html>

--- a/perl/JsonTests.pl
+++ b/perl/JsonTests.pl
@@ -1,0 +1,109 @@
+#!/usr/bin/env perl
+
+#
+# Copyright 2015 Ryan Whitworth (rwhitworth)
+# Distributed under the MIT License.
+# See LICENSE or http://opensource.org/licenses/MIT
+#
+
+use Mojolicious::Lite;
+use Digest::MD5;
+
+get '/' => sub {
+  my $c = shift;
+  $c->render(template => 'index');
+};
+
+get '/ip' => sub {
+  my $c = shift;
+  $c->res->headers->header("Content-Type" => 'application/json');
+  $c->res->headers->header("Access-Control-Allow-Origin" => '*');
+  $c->render(text => '{"ip": "' . $c->tx->remote_address . '"}');
+};
+
+get '/headers' => sub {
+  my $c = shift;
+  my $text = "{\n";
+  foreach my $x (keys %{%{$c->tx->req->content->headers}{headers}})
+  {
+    if (length($text) > 2) { $text .= ",\n"; }
+    $text .= '"' . $x . '": "' . ${$c->tx->req->content->headers}{headers}{$x}[0] . '"';
+  }
+  $text .= "\n}";
+  $c->res->headers->header("Content-Type" => 'application/json');
+  $c->res->headers->header("Access-Control-Allow-Origin" => '*');
+  $c->render(text => $text);
+};
+
+get '/date' => sub {
+  my $c = shift;
+  my $text = "{\n";
+  my $time_t = time;
+  my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($time_t);
+  $year += 1900;
+  my $timestr = sprintf("%02d:%02d:%02d ", $hour, $min, $sec);
+  if ($hour >= 13) { $timestr .= "PM"; }
+  else { $timestr .= "AM"; }
+  my $datestr = sprintf("%02d-%02d-%04d", $mon, $mday, $year);
+
+  $text .= '"time": "' . $timestr . '",' . "\n";
+  $text .= '"milliseconds_since_epoch": "' . ($time_t * 1000) . '",' . "\n";
+  $text .= '"date": "' . $datestr . '"';
+  $text .= "\n}";
+  $c->res->headers->header("Content-Type" => 'application/json');
+  $c->res->headers->header("Access-Control-Allow-Origin" => '*');
+  $c->render(text => $text);
+};
+
+get '/echo' => sub {
+  my $c = shift;
+  $c->render(text => 'not defined');
+};
+
+get '/validate' => sub {
+  my $c = shift;
+  $c->render(text => 'not defined');
+};
+
+get '/cookie' => sub {
+  my $c = shift;
+  my $time_t = time * 1000;
+  $c->cookie(time => $time_t);
+  $c->res->headers->header("Content-Type" => 'application/json');
+  $c->res->headers->header("Access-Control-Allow-Origin" => '*');
+  $c->render(text => '{"time": "' . $time_t . '"}');
+};
+
+get '/md5/:text' => sub {
+  my $c = shift;
+  my $text = '';
+  my $orig = '';
+  $orig = $c->stash('text'); 
+  $text .= "{\n" . '"md5": "' . Digest::MD5::md5_hex($orig) . '",' . "\n";
+  $text .= '"original": "' . $orig . '"' . "\n";
+  $text .= '}';
+  $c->res->headers->header("Content-Type" => 'application/json');
+  $c->res->headers->header("Access-Control-Allow-Origin" => '*');
+  $c->render(text => $text);
+};
+
+
+
+app->secrets(['passphrase1']);
+app->start;
+
+__DATA__
+
+@@ index.html.ep
+% layout 'default';
+% title 'Welcome';
+<h1>Welcome to the Mojolicious real-time web framework!</h1>
+To learn more, you can browse through the documentation
+<%= link_to 'here' => '/perldoc' %>.
+
+@@ layouts/default.html.ep
+<!DOCTYPE html>
+<html>
+  <head><title><%= title %></title></head>
+  <body><%= content %></body>
+</html>

--- a/perl/LICENSE
+++ b/perl/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Ryan Whitworth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/perl/README.md
+++ b/perl/README.md
@@ -3,29 +3,29 @@
 The goal of this project is to provide a JSON Test compatible web service that has fewer runtime requirements.  This is accomplished by using the Mojolicious framework which is easy to install on perl.  Installing mojolicious from CPAN requires no other modules outside of perl core modules.
 
 ## Services implemented
-**IP Address**
+**IP Address**<br>
 Calling http://localhost:3000/ip will return data matching the Java JSON Test response.
 
-**Headers**
+**Headers**<br>
 Calling http://localhost:3000/headers will return data matching the Java JSON Test response.
 
-**Date & Time**
+**Date & Time**<br>
 Calling http://localhost:3000/date will return data matching the Java JSON Test response.
 
-**Echo**
+**Echo**<br>
 Not implemented in the perl version.
 
-**Validation**
+**Validation**<br>
 Not implemented in the perl version.
 
-**JS Code**
+**JS Code**<br>
 Not implemented in the perl version.
 
-**Cookie**
+**Cookie**<br>
 Calling http://localhost:3000/cookie will return data similar to the Java JSON Test response.  Cookie is named time and contains the time value in milliseconds.  Example JSON:
 {"time": "1443931182000"}
 
-**MD5**
+**MD5**<br>
 Calling http://localhost:3000/md5?text=TEXT will return the MD5 sum of the TEXT parameter in the same format as the Java JSON Test response.
 
 ## Misc

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,16 +1,48 @@
 # Perl re-implementation of the JSON Test project
 
-The goal of this project is to provide a JSON Test compatible web service that has fewer runtime requirements.  This is accomplished by using the Mojolicious framework which is easy to install on perl.  Installing mojolicious from CPAN requires no other modules outside of perl core modules.
+The goal of this project is to provide a JSON Test compatible web service that has fewer runtime requirements.  This is accomplished by using the Mojolicious framework which is easy to install on perl.  Installing Mojolicious from CPAN requires no other modules outside of perl core modules.
+
+## Running the JsonTests web server
+The server can be configured as any Mojolicious program, including via PSGI or as CGI script.  These are left as exercises for the reader.
+
+To run JsonTests.pl from the command line in a development configuration run:
+````
+perl JsonTests.pl prefork
+````
 
 ## Services implemented
 **IP Address**<br>
 Calling http://localhost:3000/ip will return data matching the Java JSON Test response.
 
+Example response:
+````
+{"ip": "127.0.0.1"}
+````
+
 **Headers**<br>
 Calling http://localhost:3000/headers will return data matching the Java JSON Test response.
 
+Example response:
+````
+{
+"host": "127.0.0.1:3000",
+"user-agent": "Apache-HttpClient/4.2.6 (java 1.5)",
+"jmeter-test-script": "DO_NOT_DELETE_THIS HEADER",
+"connection": "keep-alive"
+}
+````
+
 **Date & Time**<br>
 Calling http://localhost:3000/date will return data matching the Java JSON Test response.
+
+Example response:
+````
+{
+"time": "20:50:43 PM",
+"milliseconds_since_epoch": "1454205043000",
+"date": "00-30-2016"
+}
+````
 
 **Echo**<br>
 Not implemented in the perl version.
@@ -18,19 +50,33 @@ Not implemented in the perl version.
 **Validation**<br>
 Not implemented in the perl version.
 
-**JS Code**<br>
-Not implemented in the perl version.
-
 **Cookie**<br>
-Calling http://localhost:3000/cookie will return data similar to the Java JSON Test response.  Cookie is named time and contains the time value in milliseconds.  Example JSON:
-{"time": "1443931182000"}
+Calling http://localhost:3000/cookie will return data similar to the Java JSON Test response.  Cookie is named time and contains the time value in milliseconds.  In addition to setting a cookie via HTTP headers, the response body contains a JSON response containing the same time value.
+
+Example response header:
+````
+Set-Cookie: time=1454205043000
+````
+
+Example response:
+````
+{"time": "1454205043000"}
+````
 
 **MD5**<br>
-Calling http://localhost:3000/md5?text=TEXT will return the MD5 sum of the TEXT parameter in the same format as the Java JSON Test response.
+Calling http://localhost:3000/md5/TEXT will return the MD5 sum of the TEXT parameter in the same format as the Java JSON Test response.
+
+Example response:
+````
+{
+"md5": "033bd94b1168d7e4f0d644c3c95e35bf",
+"original": "TEST"
+}
+````
 
 ## Misc
-Access-Control-Allow-Origin is configured for '*'.
-MIME type is configured as 'application/json'.
+Access-Control-Allow-Origin is configured for '*'.<br>
+MIME type is configured as 'application/json'.<br>
 Callbacks are not implemented.
 
 ## License

--- a/perl/README.md
+++ b/perl/README.md
@@ -32,3 +32,6 @@ Calling http://localhost:3000/md5?text=TEXT will return the MD5 sum of the TEXT 
 Access-Control-Allow-Origin is configured for '*'.
 MIME type is configured as 'application/json'.
 Callbacks are not implemented.
+
+## License
+Licensed under the MIT license.

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,0 +1,34 @@
+# Perl re-implementation of the JSON Test project
+
+The goal of this project is to provide a JSON Test compatible web service that has fewer runtime requirements.  This is accomplished by using the Mojolicious framework which is easy to install on perl.  Installing mojolicious from CPAN requires no other modules outside of perl core modules.
+
+## Services implemented
+**IP Address**
+Calling http://localhost:3000/ip will return data matching the Java JSON Test response.
+
+**Headers**
+Calling http://localhost:3000/headers will return data matching the Java JSON Test response.
+
+**Date & Time**
+Calling http://localhost:3000/date will return data matching the Java JSON Test response.
+
+**Echo**
+Not implemented in the perl version.
+
+**Validation**
+Not implemented in the perl version.
+
+**JS Code**
+Not implemented in the perl version.
+
+**Cookie**
+Calling http://localhost:3000/cookie will return data similar to the Java JSON Test response.  Cookie is named time and contains the time value in milliseconds.  Example JSON:
+{"time": "1443931182000"}
+
+**MD5**
+Calling http://localhost:3000/md5?text=TEXT will return the MD5 sum of the TEXT parameter in the same format as the Java JSON Test response.
+
+## Misc
+Access-Control-Allow-Origin is configured for '*'.
+MIME type is configured as 'application/json'.
+Callbacks are not implemented.

--- a/perl/jmeter-tests/JsonTest.jmx
+++ b/perl/jmeter-tests/JsonTest.jmx
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="2.8" jmeter="2.13 r1665067">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">true</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="D_SERVER" elementType="Argument">
+            <stringProp name="Argument.name">D_SERVER</stringProp>
+            <stringProp name="Argument.value">127.0.0.1</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">IP Address of web server to test</stringProp>
+          </elementProp>
+          <elementProp name="D_PORT" elementType="Argument">
+            <stringProp name="Argument.name">D_PORT</stringProp>
+            <stringProp name="Argument.value">3000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Port of web server to test</stringProp>
+          </elementProp>
+          <elementProp name="D_TIMEOUT" elementType="Argument">
+            <stringProp name="Argument.name">D_TIMEOUT</stringProp>
+            <stringProp name="Argument.value">1000</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Timeout while waiting for TCP connection or HTTP response</stringProp>
+          </elementProp>
+          <elementProp name="D_DURATION" elementType="Argument">
+            <stringProp name="Argument.name">D_DURATION</stringProp>
+            <stringProp name="Argument.value">50</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Duration in ms to wait for response from server</stringProp>
+          </elementProp>
+          <elementProp name="D_PROXY_IP" elementType="Argument">
+            <stringProp name="Argument.name">D_PROXY_IP</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="D_PROXY_PORT" elementType="Argument">
+            <stringProp name="Argument.name">D_PROXY_PORT</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="D_LOOPCOUNT" elementType="Argument">
+            <stringProp name="Argument.name">D_LOOPCOUNT</stringProp>
+            <stringProp name="Argument.value">1</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Loop thru steps this many times</stringProp>
+          </elementProp>
+          <elementProp name="D_LOCALIP" elementType="Argument">
+            <stringProp name="Argument.name">D_LOCALIP</stringProp>
+            <stringProp name="Argument.value">127.0.0.1</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">IP Address of machine running JMeter</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+          <collectionProp name="Arguments.arguments"/>
+        </elementProp>
+        <stringProp name="HTTPSampler.domain">${D_SERVER}</stringProp>
+        <stringProp name="HTTPSampler.port">${D_PORT}</stringProp>
+        <stringProp name="HTTPSampler.proxyHost">${D_PROXY_IP}</stringProp>
+        <stringProp name="HTTPSampler.proxyPort">${D_PROXY_PORT}</stringProp>
+        <stringProp name="HTTPSampler.connect_timeout">${D_TIMEOUT}</stringProp>
+        <stringProp name="HTTPSampler.response_timeout">${D_TIMEOUT}</stringProp>
+        <stringProp name="HTTPSampler.protocol"></stringProp>
+        <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+        <stringProp name="HTTPSampler.path"></stringProp>
+        <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        <stringProp name="HTTPSampler.concurrentPool">4</stringProp>
+      </ConfigTestElement>
+      <hashTree/>
+      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+        <collectionProp name="HeaderManager.headers">
+          <elementProp name="" elementType="Header">
+            <stringProp name="Header.name">JMeter-Test-Script</stringProp>
+            <stringProp name="Header.value">DO_NOT_DELETE_THIS HEADER</stringProp>
+          </elementProp>
+        </collectionProp>
+      </HeaderManager>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${D_LOOPCOUNT}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1454037315000</longProp>
+        <longProp name="ThreadGroup.end_time">1454037315000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request - /ip contains ${D_LOCALIP}" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/ip</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Duration Assertion" enabled="true">
+            <stringProp name="DurationAssertion.duration">${D_DURATION}</stringProp>
+          </DurationAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-1456741944">{&quot;ip&quot;: &quot;</stringProp>
+              <stringProp name="666259133">${D_LOCALIP}</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regular Expression Extractor" enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+            <stringProp name="RegexExtractor.refname">ip</stringProp>
+            <stringProp name="RegexExtractor.regex">ip&quot;: &quot;(.+?)&quot;</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">Not Found</stringProp>
+            <stringProp name="RegexExtractor.match_number">1</stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="false">
+          <stringProp name="IfController.condition">&quot;${ip}&quot; == &quot;127.0.0.1&quot;</stringProp>
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+        </IfController>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request - /headers" enabled="true">
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain"></stringProp>
+            <stringProp name="HTTPSampler.port"></stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="HTTPSampler.protocol"></stringProp>
+            <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+            <stringProp name="HTTPSampler.path">/headers</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.monitor">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Response Codes" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${D_LOOPCOUNT}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1454169394000</longProp>
+        <longProp name="ThreadGroup.end_time">1454169394000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Response Codes - ${URL} - ${RESPONSE}" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">${URL}</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set - Relative URLs" enabled="true">
+            <stringProp name="delimiter">,</stringProp>
+            <stringProp name="fileEncoding"></stringProp>
+            <stringProp name="filename">relativeurls.txt</stringProp>
+            <boolProp name="quotedData">false</boolProp>
+            <boolProp name="recycle">false</boolProp>
+            <stringProp name="shareMode">shareMode.all</stringProp>
+            <boolProp name="stopThread">true</boolProp>
+            <stringProp name="variableNames">URL,RESPONSE,CONTAINS_TEXT</stringProp>
+          </CSVDataSet>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP Response Code Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-2135555739">${RESPONSE}</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">8</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP Response Body Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-1847845017">${CONTAINS_TEXT}</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Duration Assertion" enabled="true">
+            <stringProp name="DurationAssertion.duration">${D_DURATION}</stringProp>
+          </DurationAssertion>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>true</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <url>true</url>
+            <fileName>true</fileName>
+            <hostname>true</hostname>
+            <threadCounts>true</threadCounts>
+            <sampleCount>true</sampleCount>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename">test.log</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/perl/jmeter-tests/relativeurls.txt
+++ b/perl/jmeter-tests/relativeurls.txt
@@ -1,0 +1,10 @@
+/ip,200,ip
+/headers,200,jmeter-test-script
+/failure,404,
+/date,200,milliseconds_since_epoch
+/echo,200,not defined
+/validate,200,not defined
+/jscode,404,
+/cookie,200,time
+/md5/TEST,200,033bd94b1168d7e4f0d644c3c95e35bf
+/md5/TEST1,200,db03fa33c1e2ca35794adbb14aebb153


### PR DESCRIPTION
Created a lower requirements version of the JSON Test web services.  It is written in perl and only requires the Mojolicious framework, which requires modules from perl core.
